### PR TITLE
Type `object|string` doesn't seem to be recongized

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
                 },
                 "stylint.stylintrcPath": {
                     "scope": "resource",
-                    "type": "object | string",
+                    "type": "string",
                     "default": ".stylintrc",
                     "description": "The path to the .stylintrc file containing the options (see https://github.com/SimenB/stylint#options)."
                 },


### PR DESCRIPTION
VSCode (v1.29.1, OSX) complains "_Incorrect type. Expected "object | string"._" no matter what I set this config value to.